### PR TITLE
Address "Exceptional forms in general" section of Porter 2.

### DIFF
--- a/stemmer.js
+++ b/stemmer.js
@@ -105,7 +105,7 @@ var stemmer = (function(){
 
 		// Step 1c
 	        re = new RegExp("^(.+" + c + ")y$");
-		    if (re.test(w) && w != "sky") {
+		    if (re.test(w)) {
 			var fp = re.exec(w);
 			stem = fp[1];
 		    w = stem + "i";
@@ -180,6 +180,55 @@ var stemmer = (function(){
 			w = firstch.toLowerCase() + w.substr(1);
 		}
 
-		return w;
+	    // See http://snowball.tartarus.org/algorithms/english/stemmer.html
+	    // "Exceptional forms in general"
+	    var specialWords = {
+	    	"skis" : "ski",
+	    	"skies" : "sky",
+	    	"dying" : "die",
+	    	"lying" : "lie",
+	    	"tying" : "tie",
+	    	"idly" : "idl",
+	    	"gently" : "gentl",
+	    	"ugly" : "ugli",
+	    	"early": "earli",
+	    	"only": "onli",
+	    	"singly": "singl"
+	    };
+
+	    if(specialWords[origword]){
+	    	w = specialWords[origword];
+	    }
+
+	    if( "sky news howe atlas cosmos bias \
+	    	 andes inning outing canning herring \
+	    	 earring proceed exceed succeed".indexOf(origword) !== -1 ){
+	    	w = origword;
+	    }
+
+	    // Address words overstemmed as gener-
+	    re = /.*generate?s?d?(ing)?$/;
+	    if( re.test(origword) ){
+		w = w + 'at';
+	    }
+	    re = /.*general(ly)?$/;
+	    if( re.test(origword) ){
+		w = w + 'al';
+	    }
+	    re = /.*generic(ally)?$/;
+	    if( re.test(origword) ){
+		w = w + 'ic';
+	    }
+	    re = /.*generous(ly)?$/;
+	    if( re.test(origword) ){
+		w = w + 'ous';
+	    }
+	    // Address words overstemmed as commun-
+	    re = /.*communit(ies)?y?/;
+	    if( re.test(origword) ){
+		w = w + 'iti';
+	    }
+
+	    return w;
 	}
 })();


### PR DESCRIPTION
Hi Chris,
Further investigation revealed that a whole section of the Porter 2 algorithm was not implemented in the js stemmer. This means that when used with an index created by another implementation (e.g. the Java stemmer), forms of the words generate, community,  sky, etc. weren't found. The spec also mentions "arsen-"  words as a problem (like 'gener-' and 'commun-' are), but I can't reproduce the problem with any arsen- words. 

David
