### PR TITLE
Use hasOwnProperty to test if property exists

### DIFF
--- a/stemmer.js
+++ b/stemmer.js
@@ -196,7 +196,7 @@ var stemmer = (function(){
 	    	"singly": "singl"
 	    };
 
-	    if(specialWords[origword]){
+	    if(specialWords.hasOwnProperty(origword)){
 	    	w = specialWords[origword];
 	    }
 


### PR DESCRIPTION
Trying things like:

stemmer("**proto**")

Or in Firefox

stemmer("watch")

Or other things that are properties of an object instance (https://developer.mozilla.org/en-US/docs/JavaScript/Reference/Global_Objects/Object) and the stemmer will return the object function instead of a string.
